### PR TITLE
Make numpy not a dependency of UFLx

### DIFF
--- a/external/basix_uflx/pyproject.toml
+++ b/external/basix_uflx/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     { name = "Matthew Scroggs", email = "ufl@mscroggs.co.uk" },
     { name = "Garth Wells", email = "gnw20@cam.ac.uk" }
 ]
-dependencies = ["uflx", "numpy", "cffi", "setuptools", "fenics-basix", "uflx-codegeneration"]
+dependencies = ["uflx", "numpy", "fenics-basix", "uflx-codegeneration"]
 
 [project.urls]
 homepage = "https://github.com/garth-wells/uflx"

--- a/external/codegeneration/uflx_codegeneration/algorithms.py
+++ b/external/codegeneration/uflx_codegeneration/algorithms.py
@@ -9,11 +9,11 @@ from uflx.finite_elements import AbstractEvaluatedBasisFunction
 from uflx.geometry import JacobianDeterminant, expand_geometry
 from uflx.graphs import Graph, GraphNode
 from uflx.graphs.algorithms import replace
-from uflx.points import PointInSet
 
 from uflx_codegeneration import symbols
 from uflx_codegeneration.finite_element import AbstractFiniteElement
 from uflx_codegeneration.nodes import ArrayEntry, FunctionCall, Variable
+from uflx_codegeneration.points import AbstractPointInSet
 from uflx_codegeneration.utils import index
 
 
@@ -27,7 +27,7 @@ def tabulate_finite_elements(
     table_info: dict[str, tuple[AbstractFiniteElement, int, npt.NDArray[np.floating]]] = {}
     for node in graph:
         if isinstance(node, GraphNode) and isinstance(node, AbstractEvaluatedBasisFunction):
-            assert isinstance(node.point, PointInSet)
+            assert isinstance(node.point, AbstractPointInSet)
             id = (node.element, node.point.points_id)
             if id in table_map:
                 name = table_map[id]

--- a/external/codegeneration/uflx_codegeneration/c.py
+++ b/external/codegeneration/uflx_codegeneration/c.py
@@ -6,7 +6,6 @@ import numpy as np
 from uflx.expressions import Abs, Add, Mult, Subtract
 from uflx.geometry import CoordinateDofComponent
 from uflx.points import PointComponent
-from uflx.quadrature import QuadratureLoop
 
 from uflx_codegeneration import symbols
 from uflx_codegeneration.utils import indented
@@ -83,20 +82,6 @@ def abs_generate_c(self) -> str:
 
 
 setattr(Abs, "generate_c", abs_generate_c)
-
-
-def ql_generate_c(self) -> str:
-    """Generate code for this object."""
-    if not isinstance(self.body, GenerateC):
-        raise NotImplementedError(f"GenerateC is not implemented for {self.body.__class__}")
-    return (
-        f"for (int {self.variable}=0; {self.variable}!={self.rule.npoints}; "
-        f"++{self.variable})\n"
-        "{\n" + indented(self.body.generate_c(), 2) + "\n}"
-    )
-
-
-setattr(QuadratureLoop, "generate_c", ql_generate_c)
 
 
 def pc_generate_c(self) -> str:

--- a/external/codegeneration/uflx_codegeneration/c.py
+++ b/external/codegeneration/uflx_codegeneration/c.py
@@ -8,7 +8,6 @@ from uflx.geometry import CoordinateDofComponent
 from uflx.points import PointComponent
 
 from uflx_codegeneration import symbols
-from uflx_codegeneration.utils import indented
 
 
 @runtime_checkable

--- a/external/codegeneration/uflx_codegeneration/generate.py
+++ b/external/codegeneration/uflx_codegeneration/generate.py
@@ -206,11 +206,45 @@ def generate(
         dx: quadrature_rule([[1 / 6, 1 / 6], [2 / 3, 1 / 6], [1 / 6, 2 / 3]], [1 / 6, 1 / 6, 1 / 6])
     }
 
+    graph.print()
+    print()
+    print("----")
+    print()
+
     graph = integrals_to_quadrature(graph, rules)
+
+    graph.print()
+    print()
+    print("----")
+    print()
+
     graph = apply_push_forwards(graph)
+
+    graph.print()
+    print()
+    print("----")
+    print()
+
     geometry_functions, graph = insert_geometry_functions(graph)
+
+    graph.print()
+    print()
+    print("----")
+    print()
+
     graph = expand_geometry(graph)
+
+    graph.print()
+    print()
+    print("----")
+    print()
+
     graph = take_real_part(graph)
+
+    graph.print()
+    print()
+    print("----")
+    print()
 
     q_tables, graph = tabulate_quadrature(graph)
     fe_tables, graph = tabulate_finite_elements(graph)

--- a/external/codegeneration/uflx_codegeneration/generate.py
+++ b/external/codegeneration/uflx_codegeneration/generate.py
@@ -17,18 +17,18 @@ from uflx.graphs.algorithms import replace
 from uflx.integrals import AbstractIntegral, AbstractMeasure, Measure, dx
 from uflx.maps import PushedForward, apply_push_forwards
 from uflx.points import Point, PointComponent
-from uflx.quadrature import (
+
+from uflx_codegeneration import symbols
+from uflx_codegeneration.algorithms import insert_geometry_functions, tabulate_finite_elements
+from uflx_codegeneration.c import GenerateC, tables_to_c
+from uflx_codegeneration.nodes import AddToLocalTensor, ArrayEntry, Loop
+from uflx_codegeneration.quadrature import (
     QuadratureLoop,
     QuadraturePoint,
     QuadratureRule,
     QuadratureWeight,
     quadrature_rule,
 )
-
-from uflx_codegeneration import symbols
-from uflx_codegeneration.algorithms import insert_geometry_functions, tabulate_finite_elements
-from uflx_codegeneration.c import GenerateC, tables_to_c
-from uflx_codegeneration.nodes import AddToLocalTensor, ArrayEntry, Loop
 from uflx_codegeneration.utils import indented
 
 

--- a/external/codegeneration/uflx_codegeneration/generate.py
+++ b/external/codegeneration/uflx_codegeneration/generate.py
@@ -206,45 +206,11 @@ def generate(
         dx: quadrature_rule([[1 / 6, 1 / 6], [2 / 3, 1 / 6], [1 / 6, 2 / 3]], [1 / 6, 1 / 6, 1 / 6])
     }
 
-    graph.print()
-    print()
-    print("----")
-    print()
-
     graph = integrals_to_quadrature(graph, rules)
-
-    graph.print()
-    print()
-    print("----")
-    print()
-
     graph = apply_push_forwards(graph)
-
-    graph.print()
-    print()
-    print("----")
-    print()
-
     geometry_functions, graph = insert_geometry_functions(graph)
-
-    graph.print()
-    print()
-    print("----")
-    print()
-
     graph = expand_geometry(graph)
-
-    graph.print()
-    print()
-    print("----")
-    print()
-
     graph = take_real_part(graph)
-
-    graph.print()
-    print()
-    print("----")
-    print()
 
     q_tables, graph = tabulate_quadrature(graph)
     fe_tables, graph = tabulate_finite_elements(graph)
@@ -277,7 +243,6 @@ def generate(
     code += indented(tables_to_c(tables), 2)
     code += "\n\n"
     assert isinstance(graph.root, GenerateC)
-    graph.print()
     code += indented(graph.root.generate_c(), 2)
     code += "\n}\n"
 

--- a/external/codegeneration/uflx_codegeneration/generate.py
+++ b/external/codegeneration/uflx_codegeneration/generate.py
@@ -243,6 +243,7 @@ def generate(
     code += indented(tables_to_c(tables), 2)
     code += "\n\n"
     assert isinstance(graph.root, GenerateC)
+    graph.print()
     code += indented(graph.root.generate_c(), 2)
     code += "\n}\n"
 

--- a/external/codegeneration/uflx_codegeneration/points.py
+++ b/external/codegeneration/uflx_codegeneration/points.py
@@ -14,3 +14,8 @@ class AbstractPointInSet(UFLxAbstractPointInSet):
     @abstractmethod
     def points(self) -> npt.NDArray[np.floating]:
         """Get all the points in the set."""
+
+    @property
+    def dim(self) -> int:
+        """The dimension of the point."""
+        return self.points.shape[1]

--- a/external/codegeneration/uflx_codegeneration/points.py
+++ b/external/codegeneration/uflx_codegeneration/points.py
@@ -1,0 +1,21 @@
+"""Sets of points."""
+
+from abc import abstractmethod
+from collections.abc import Hashable
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+
+from uflx.points import AbstractPointInSet as UFLxAbstractPointInSet
+from uflx.expressions import AbstractExpression
+from uflx.graphs import GraphNode
+
+
+class AbstractPointInSet(UFLxAbstractPointInSet):
+    """Base class for a point in a set of points."""
+
+    @property
+    @abstractmethod
+    def points(self) -> npt.NDArray[np.floating]:
+        """Get all the points in the set."""

--- a/external/codegeneration/uflx_codegeneration/points.py
+++ b/external/codegeneration/uflx_codegeneration/points.py
@@ -1,15 +1,10 @@
 """Sets of points."""
 
 from abc import abstractmethod
-from collections.abc import Hashable
-from typing import Any
 
 import numpy as np
 import numpy.typing as npt
-
 from uflx.points import AbstractPointInSet as UFLxAbstractPointInSet
-from uflx.expressions import AbstractExpression
-from uflx.graphs import GraphNode
 
 
 class AbstractPointInSet(UFLxAbstractPointInSet):

--- a/external/codegeneration/uflx_codegeneration/quadrature.py
+++ b/external/codegeneration/uflx_codegeneration/quadrature.py
@@ -5,7 +5,6 @@ from typing import Any
 
 import numpy as np
 import numpy.typing as npt
-
 from uflx.expressions import AbstractExpression
 from uflx.graphs import GraphNode
 

--- a/external/codegeneration/uflx_codegeneration/quadrature.py
+++ b/external/codegeneration/uflx_codegeneration/quadrature.py
@@ -8,9 +8,10 @@ import numpy.typing as npt
 
 from uflx.expressions import AbstractExpression
 from uflx.graphs import GraphNode
-from uflx.points import PointInSet
 
-from uflx_codegeneration import GenerateC
+from uflx_codegeneration.c import GenerateC
+from uflx_codegeneration.points import AbstractPointInSet
+from uflx_codegeneration.utils import indented
 
 
 class QuadratureRule:
@@ -27,7 +28,7 @@ class QuadratureRule:
         return len(self.weights)
 
 
-class QuadraturePoint(PointInSet):
+class QuadraturePoint(AbstractPointInSet):
     """A point in a quadrature rule."""
 
     def __init__(self, rule: QuadratureRule, index: int | str):

--- a/external/codegeneration/uflx_codegeneration/quadrature.py
+++ b/external/codegeneration/uflx_codegeneration/quadrature.py
@@ -10,6 +10,8 @@ from uflx.expressions import AbstractExpression
 from uflx.graphs import GraphNode
 from uflx.points import PointInSet
 
+from uflx_codegeneration import GenerateC
+
 
 class QuadratureRule:
     """A quadrature rule."""
@@ -114,10 +116,20 @@ class QuadratureLoop:
         """The arguments used to initialise this object."""
         return self.body, self.rule, self.variable
 
+    def generate_c(self) -> str:
+        """Generate code for this object."""
+        if not isinstance(self.body, GenerateC):
+            raise NotImplementedError(f"GenerateC is not implemented for {self.body.__class__}")
+        return (
+            f"for (int {self.variable}=0; {self.variable}!={self.rule.npoints}; "
+            f"++{self.variable})\n"
+            "{\n" + indented(self.body.generate_c(), 2) + "\n}"
+        )
+
 
 def quadrature_rule(
-    points: Sequence[Sequence[float]],
-    weights: Sequence[float],
+    points: Sequence[Sequence[float]] | npt.ArrayLike,
+    weights: Sequence[float] | npt.ArrayLike,
 ) -> QuadratureRule:
     """Create a quadrature rule."""
     return QuadratureRule(np.array(points), np.array(weights))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     { name = "Matthew Scroggs", email = "ufl@mscroggs.co.uk" },
     { name = "Garth Wells", email = "gnw20@cam.ac.uk" }
 ]
-dependencies = ["networkx", "numpy"]
+dependencies = ["networkx"]
 
 [tool.setuptools.packages.find]
 exclude = ["external"]

--- a/uflx/finite_elements.py
+++ b/uflx/finite_elements.py
@@ -18,7 +18,7 @@ from uflx.entities import AbstractEntity
 from uflx.expressions import AbstractExpression
 from uflx.graphs import GraphNode
 from uflx.maps import AbstractReferenceMap
-from uflx.points import AbstractPoint, PointInSet
+from uflx.points import AbstractPoint, AbstractPointInSet
 from uflx.utils import product
 
 
@@ -195,7 +195,7 @@ class EvaluatedBasisFunction(AbstractEvaluatedBasisFunction):
     @property
     def point_index(self) -> int | str:
         """The index of the point in the set of points."""
-        if isinstance(self._point, PointInSet):
+        if isinstance(self._point, AbstractPointInSet):
             return self._point.index
         return 0
 

--- a/uflx/geometry.py
+++ b/uflx/geometry.py
@@ -124,7 +124,7 @@ class ReferenceToPhysical(AbstractPoint):
                     i // dim, i % dim, dim
                 ) * EvaluatedBasisFunction(element, i, self.reference_point, component=j)
 
-        return Point(*components)
+        return Point(components)
 
 
 class JacobianDeterminant(AbstractExpression):

--- a/uflx/graphs/__init__.py
+++ b/uflx/graphs/__init__.py
@@ -9,5 +9,4 @@ from uflx.graphs.graphs import (
     GraphNode,
     RepresentedByGraph,
     generate_graph,
-    reconstruct_node,
 )

--- a/uflx/graphs/algorithms/__init__.py
+++ b/uflx/graphs/algorithms/__init__.py
@@ -1,3 +1,4 @@
 """Graph algorithms."""
 
 from uflx.graphs.algorithms.replace import replace
+from uflx.graphs.algorithms.reconstruct import reconstruct_node

--- a/uflx/graphs/algorithms/__init__.py
+++ b/uflx/graphs/algorithms/__init__.py
@@ -1,4 +1,4 @@
 """Graph algorithms."""
 
-from uflx.graphs.algorithms.replace import replace
 from uflx.graphs.algorithms.reconstruct import reconstruct_node
+from uflx.graphs.algorithms.replace import replace

--- a/uflx/graphs/algorithms/reconstruct.py
+++ b/uflx/graphs/algorithms/reconstruct.py
@@ -1,0 +1,28 @@
+"""Reconstruct."""
+from typing import Any
+
+from uflx.graphs.graphs import GraphNode
+
+
+def apply_replacements(arg: Any, replacements: dict[GraphNode, GraphNode]) -> Any:
+    """Apply replacements to an init arg."""
+    if isinstance(arg, GraphNode):
+        return replacements.get(arg, arg)
+    if isinstance(arg, list):
+        return [apply_replacements(i, replacements) for i in arg]
+    if isinstance(arg, tuple):
+        return tuple(apply_replacements(i, replacements) for i in arg)
+    if isinstance(arg, dict):
+        return {
+            apply_replacements(i, replacements): apply_replacements(j, replacements)
+            for i, j in arg.items()
+        }
+
+    return arg
+
+
+
+def reconstruct_node(node: GraphNode, replacements: dict[GraphNode, GraphNode]) -> GraphNode:
+    """Reconstruct a node with replacements made."""
+    args = [apply_replacements(i, replacements) for i in node.init_args]
+    return node.__class__(*args)

--- a/uflx/graphs/algorithms/reconstruct.py
+++ b/uflx/graphs/algorithms/reconstruct.py
@@ -1,4 +1,5 @@
 """Reconstruct."""
+
 from typing import Any
 
 from uflx.graphs.graphs import GraphNode
@@ -19,7 +20,6 @@ def apply_replacements(arg: Any, replacements: dict[GraphNode, GraphNode]) -> An
         }
 
     return arg
-
 
 
 def reconstruct_node(node: GraphNode, replacements: dict[GraphNode, GraphNode]) -> GraphNode:

--- a/uflx/graphs/algorithms/replace.py
+++ b/uflx/graphs/algorithms/replace.py
@@ -2,7 +2,8 @@
 
 import networkx as nx
 
-from uflx.graphs.graphs import Graph, GraphNode, generate_graph, reconstruct_node
+from uflx.graphs.graphs import Graph, GraphNode, generate_graph
+from uflx.graphs.algorithms.reconstruct import reconstruct_node
 
 
 def replace(graph: Graph, replacements: dict[GraphNode, GraphNode]) -> Graph:

--- a/uflx/graphs/algorithms/replace.py
+++ b/uflx/graphs/algorithms/replace.py
@@ -2,8 +2,8 @@
 
 import networkx as nx
 
-from uflx.graphs.graphs import Graph, GraphNode, generate_graph
 from uflx.graphs.algorithms.reconstruct import reconstruct_node
+from uflx.graphs.graphs import Graph, GraphNode, generate_graph
 
 
 def replace(graph: Graph, replacements: dict[GraphNode, GraphNode]) -> Graph:

--- a/uflx/graphs/graphs.py
+++ b/uflx/graphs/graphs.py
@@ -99,9 +99,3 @@ def generate_graph(node: GraphNode) -> Graph:
         added_nodes = set().union(*[n.successors for n in added_nodes])
 
     return graph
-
-
-def reconstruct_node(node: GraphNode, replacements: dict[GraphNode, GraphNode]) -> GraphNode:
-    """Reconstruct a node with replacements made."""
-    args = [replacements.get(i, i) if isinstance(i, GraphNode) else i for i in node.init_args]
-    return node.__class__(*args)

--- a/uflx/points.py
+++ b/uflx/points.py
@@ -4,15 +4,12 @@ from abc import abstractmethod
 from collections.abc import Hashable
 from typing import Any
 
-import numpy as np
-import numpy.typing as npt
-
 from uflx.expressions import AbstractExpression
 from uflx.graphs import GraphNode
 
 
 class AbstractPoint(AbstractExpression):
-    """A single point in R^d."""
+    """Base class for a single point in R^d."""
 
     @property
     @abstractmethod
@@ -32,7 +29,7 @@ class AbstractPoint(AbstractExpression):
 class Point(AbstractPoint):
     """A single point in R^d."""
 
-    def __init__(self, *components: AbstractExpression):
+    def __init__(self, components: AbstractExpression):
         """Initialise."""
         self._components = components
 
@@ -55,16 +52,11 @@ class Point(AbstractPoint):
     @property
     def init_args(self) -> tuple[Any, ...]:
         """The arguments used to initialise this object."""
-        return tuple(self._components)
+        return (self._components,)
 
 
-class PointInSet(AbstractPoint):
-    """A single point in a set of points."""
-
-    @property
-    @abstractmethod
-    def points(self) -> npt.NDArray[np.floating]:
-        """Get all the points in the set."""
+class AbstractPointInSet(AbstractPoint):
+    """Base class for a point in a set of points."""
 
     @property
     def dim(self) -> int:

--- a/uflx/points.py
+++ b/uflx/points.py
@@ -1,7 +1,7 @@
 """Sets of points."""
 
 from abc import abstractmethod
-from collections.abc import Hashable
+from collections.abc import Hashable, Sequence
 from typing import Any
 
 from uflx.expressions import AbstractExpression
@@ -29,9 +29,9 @@ class AbstractPoint(AbstractExpression):
 class Point(AbstractPoint):
     """A single point in R^d."""
 
-    def __init__(self, components: AbstractExpression):
+    def __init__(self, components: Sequence[AbstractExpression]):
         """Initialise."""
-        self._components = components
+        self._components = tuple(components)
 
     @property
     def dim(self) -> int:
@@ -59,9 +59,9 @@ class AbstractPointInSet(AbstractPoint):
     """Base class for a point in a set of points."""
 
     @property
+    @abstractmethod
     def dim(self) -> int:
         """The dimension of the point."""
-        return self.points.shape[1]
 
     @property
     @abstractmethod


### PR DESCRIPTION
- Move quadrature rules to cogeneration. Close #27.
- Remove `points` function of `PointInSet` that returns numpy array and put it into a new base class in codegeneration.
- Updated reconstruct so that it handles args that are lists

Close #28.