### PR TITLE
Add 3x3 case to Matrix.compute_inverse

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ repository = "https://github.com/garth-wells/uflx"
 [project.optional-dependencies]
 docs = ["sphinx", "sphinx-autoapi", "pydata_sphinx_theme"]
 lint = ["ruff", "pyrefly"]
-ci = ["pytest", "pytest-xdist"]
+ci = ["pytest", "pytest-xdist", "numpy"]
 
 [tool.ruff]
 line-length = 100

--- a/test/test_tensors.py
+++ b/test/test_tensors.py
@@ -1,0 +1,66 @@
+"""Test uflx.tensors.Matrix's compute_inverse/compute_determinant."""
+
+import numpy as np
+import pytest
+
+from uflx.expressions import Add, Div, Integer, Mult, Neg, RealScalar, Subtract
+from uflx.tensors import Matrix
+
+
+def _evaluate(expr) -> float:
+    """Numerically evaluate an expression tree.
+
+    Handles trees built only from RealScalar literals and +, -, *, / --
+    enough for these tests, not a general evaluator.
+    """
+    if isinstance(expr, (RealScalar, Integer)):
+        return float(expr.value)
+    if isinstance(expr, Add):
+        return _evaluate(expr.first) + _evaluate(expr.second)
+    if isinstance(expr, Subtract):
+        return _evaluate(expr.first) - _evaluate(expr.second)
+    if isinstance(expr, Mult):
+        return _evaluate(expr.first) * _evaluate(expr.second)
+    if isinstance(expr, Div):
+        return _evaluate(expr.first) / _evaluate(expr.second)
+    if isinstance(expr, Neg):
+        return -_evaluate(expr.argument)
+    raise NotImplementedError(f"Cannot evaluate {type(expr)}")
+
+
+def _to_matrix(values: np.ndarray) -> Matrix:
+    return Matrix([[RealScalar(float(v)) for v in row] for row in values])
+
+
+def _to_numpy(matrix: Matrix) -> np.ndarray:
+    rows, cols = matrix.value_shape
+    return np.array([[_evaluate(matrix.component(i, j)) for j in range(cols)] for i in range(rows)])
+
+
+@pytest.mark.parametrize("n", [1, 2, 3])
+def test_compute_inverse(n):
+    """compute_inverse() should match numpy's inverse for 1x1, 2x2 and 3x3."""
+    rng = np.random.default_rng(0)
+    values = rng.uniform(0.5, 2.0, (n, n))
+
+    inverse = _to_numpy(_to_matrix(values).compute_inverse())
+
+    np.testing.assert_allclose(inverse, np.linalg.inv(values), rtol=1e-12)
+
+
+@pytest.mark.parametrize("n", [1, 2, 3])
+def test_compute_determinant(n):
+    """compute_determinant() should match numpy's determinant for 1x1, 2x2 and 3x3."""
+    rng = np.random.default_rng(1)
+    values = rng.uniform(0.5, 2.0, (n, n))
+
+    det = _evaluate(_to_matrix(values).compute_determinant())
+
+    np.testing.assert_allclose(det, np.linalg.det(values), rtol=1e-12)
+
+
+def test_compute_inverse_not_implemented_for_4x4():
+    """compute_inverse() should still raise a clear error for unsupported sizes."""
+    matrix = _to_matrix(np.eye(4))
+    with pytest.raises(NotImplementedError):
+        matrix.compute_inverse()

--- a/uflx/tensors.py
+++ b/uflx/tensors.py
@@ -153,8 +153,40 @@ class Matrix(Tensor):
                     assert isinstance(d, AbstractExpression)
                     det = a * d - b * c
                     return Matrix([[d / det, -b / det], [-c / det, a / det]])
+                case 3:
+                    [[a, b, c], [d, e, f], [g, h, i]] = entries
+                    assert isinstance(a, AbstractExpression)
+                    assert isinstance(b, AbstractExpression)
+                    assert isinstance(c, AbstractExpression)
+                    assert isinstance(d, AbstractExpression)
+                    assert isinstance(e, AbstractExpression)
+                    assert isinstance(f, AbstractExpression)
+                    assert isinstance(g, AbstractExpression)
+                    assert isinstance(h, AbstractExpression)
+                    assert isinstance(i, AbstractExpression)
+                    det = a * (e * i - f * h) + b * (f * g - d * i) + c * (d * h - e * g)
+                    # Inverse = adjugate / det, adjugate = cofactor matrix transposed.
+                    return Matrix(
+                        [
+                            [
+                                (e * i - f * h) / det,
+                                (c * h - b * i) / det,
+                                (b * f - c * e) / det,
+                            ],
+                            [
+                                (f * g - d * i) / det,
+                                (a * i - c * g) / det,
+                                (c * d - a * f) / det,
+                            ],
+                            [
+                                (d * h - e * g) / det,
+                                (b * g - a * h) / det,
+                                (a * e - b * d) / det,
+                            ],
+                        ]
+                    )
                 case _:
-                    raise NotImplementedError("Inverting of {rows}x{rows} not implemented.")
+                    raise NotImplementedError(f"Inverting of {rows}x{rows} not implemented.")
 
     def compute_determinant(self) -> AbstractExpression:
         """Compute the inverse of the matrix."""


### PR DESCRIPTION
compute_determinant() already handles 3x3 matrices via cofactor expansion, but compute_inverse() only covered up to 2x2 and raised NotImplementedError for anything larger. This adds the 3x3 case using the standard adjugate (transposed cofactor matrix) / determinant formula, needed for JacobianInverse.expand_geometry() on any codim-0 domain in 3D (e.g. a tetrahedron cell) -- currently that raises for every 3D mesh.

Also fixes a latent bug in the case _ error message, which was a plain string literal rather than an f-string, so it never actually interpolated the matrix size.

Adds test/test_tensors.py covering compute_inverse/compute_determinant for 1x1, 2x2 and 3x3 against numpy, plus the still-NotImplementedError 4x4 case.

Written with Claude Sonnet 5